### PR TITLE
reversion unique index hint 추가

### DIFF
--- a/reversion/revisions.py
+++ b/reversion/revisions.py
@@ -191,7 +191,14 @@ def _add_to_revision(obj, using, model_db, explicit):
     )
     # If the version is a duplicate, stop now.
     if version_options.ignore_duplicates and explicit:
-        previous_version = Version.objects.using(using).get_for_object(obj, model_db=model_db).first()
+        from django_mysql.models import add_QuerySetMixin
+
+        previous_version = (
+            add_QuerySetMixin(Version.objects.using(using).get_for_object(obj, model_db=model_db))
+            .use_index("reversion_version_db_content_type_id_objec_b2c54f65_uniq")
+            .first()
+        )
+
         if previous_version and previous_version._local_field_dict == version._local_field_dict:
             return
     # Store the version.

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     cmdclass=cmdclass,
     install_requires=[
         "django>=3.2",
+        "django-mysql==3.8.1",
     ],
     python_requires='>=3.7',
     classifiers=[

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -96,6 +96,7 @@ DATABASES = {
         "PASSWORD": os.environ.get("DJANGO_DATABASE_PASSWORD_MYSQL", ""),
     },
 }
+DJANGO_MYSQL_REWRITE_QUERIES: bool = True
 
 
 # Password validation


### PR DESCRIPTION
django_mysql QuerySetMixin 기능을 활용해 인덱스 힌트를 추가합니다.

reversion 자체 테스트,
ably-server에서 쿼리봤을 때 use_index 잘 타는것 확인했습니다.

```sql
SELECT `reversion_version`.`id`,
       `reversion_version`.`revision_id`,
       `reversion_version`.`object_id`,
       `reversion_version`.`content_type_id`,
       `reversion_version`.`db`,
       `reversion_version`.`format`,
       `reversion_version`.`serialized_data`,
       `reversion_version`.`object_repr`
  FROM `reversion_version` USE INDEX (`reversion_version_db_content_type_id_objec_b2c54f65_uniq`)
 WHERE (`reversion_version`.`content_type_id` = 27 AND `reversion_version`.`db` = 'default' AND `reversion_version`.`object_id` = '1664517390925' AND (1))
 ORDER BY `reversion_version`.`id` DESC
 LIMIT 1
 ```
