### PR TITLE
django-mysql 버전 변경

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     cmdclass=cmdclass,
     install_requires=[
         "django>=3.2",
-        "django-mysql==3.8.1",
+        "django-mysql>=4.7.1",
     ],
     python_requires='>=3.7',
     classifiers=[


### PR DESCRIPTION
django-mysql changelog: https://django-mysql.readthedocs.io/en/latest/changelog.html

ably-server django버전 업그레이드를 위해서 django-mysql 버전을 올립니다.
ably-server도 django-mysql버전을 올려도 상관없어보입니다.

이 PR 머지 후 바로 ably-server도 django-mysql 버전도 4.7.1로 변경하겠습니다.